### PR TITLE
fix a typo in dkms make_install.sh

### DIFF
--- a/dkms/make_install.sh
+++ b/dkms/make_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 sudo cp -r x86_adapt* /usr/src
-sudo dkms add -m x86_adapt_definition -v 0.1
+sudo dkms add -m x86_adapt_defs -v 0.1
 sudo dkms add -m x86_adapt_driver -v 0.3
 
 sudo dkms build -m x86_adapt_defs -v 0.1


### PR DESCRIPTION
There is a typo in the dkms make scripts which avoids them to install.

By the way should't we increase the version number? Or at least force the installation? Otherwise updates won't be applied as the version number does not increase.

Best,

Andreas