### PR TITLE
Change shebangs to work on systems where python->python3 and python->python2

### DIFF
--- a/definition_driver/knobs/write_uncore_pmc_definitions.py
+++ b/definition_driver/knobs/write_uncore_pmc_definitions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 class HaswellPciBox:
 	prefix=None

--- a/definition_driver/prepare.py
+++ b/definition_driver/prepare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 #avoid bytecode files, which are not tracked by dpkg
 #which would cause errors when removing the deb package


### PR DESCRIPTION
[PEP-0394](https://www.python.org/dev/peps/pep-0394/) specifies that all installations  of Python 2 should contain a python2 executable so this should(tm) work everywhere