### PR TITLE
Add compatibility with Linux 5.3

### DIFF
--- a/driver/x86_adapt_driver.c
+++ b/driver/x86_adapt_driver.c
@@ -719,7 +719,11 @@ static int read_setting(int dev_nr, struct knob_entry knob,u64 * reading)
             case MSR:
                 if (!cpu_online(dev_nr))
                     return -ENXIO;
+                #if LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)
                 if ( cpumask_equal(get_cpu_mask(dev_nr),&(current->cpus_allowed))) {
+                #else
+                if ( cpumask_equal(get_cpu_mask(dev_nr),current->cpus_ptr)) {
+                #endif
                     register_reading = native_read_msr(knob.register_index);
                 }
                 else {
@@ -925,7 +929,11 @@ static int write_setting(int dev_nr, struct knob_entry knob, u64 setting)
         switch (knob.device) {
             /* write to msr */
             case MSR:
-                if (cpumask_equal(get_cpu_mask(dev_nr),&(current->cpus_allowed))) {
+                #if LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0)
+                if ( cpumask_equal(get_cpu_mask(dev_nr),&(current->cpus_allowed))) {
+                #else
+                if ( cpumask_equal(get_cpu_mask(dev_nr),current->cpus_ptr)) {
+                #endif
                     native_write_msr(knob.register_index,l,h);
                 }
                 else {


### PR DESCRIPTION
Linux 5.3 made some changes to `task_struct` following the removal of the `tsk_nr_cpus_allowed()` wrapper, which included adding a pointer to `task_struct` pointing to the `cpumask_t cpus_allowed`.
For some reason, this also included a renaming of `cpus_allowed` to `cpus_mask` (see patches in
[this thread on the LKML](https://lore.kernel.org/lkml/20190423142636.14347-1-bigeasy@linutronix.de/)), which breaks x86_adapt's compatibility with Linux 5.3 and newer.
This commit fixes that.

Changes:

* Add usage of `current->cpu_ptr` instead of `&(current->cpus_allowed)`
if Linux is version 5.3 or newer