### PR TITLE
Bugfix: added encoding to open-calls

### DIFF
--- a/definition_driver/cpu.py
+++ b/definition_driver/cpu.py
@@ -6,7 +6,7 @@ class ProcessorGroup():
     models=[]
     def __init__(self, inputfilename):
         self.name=inputfilename[inputfilename.rfind('/')+1:inputfilename.rfind('.')]
-        inputfile=open(inputfilename)
+        inputfile=open(inputfilename, encoding='utf-8')
         data = list(inputfile)
         self.models=[]
         self.families=[]

--- a/definition_driver/knob.py
+++ b/definition_driver/knob.py
@@ -36,7 +36,7 @@ class Knob():
         self.cpuid=None
         self.override_name=self.name
 
-        inputfile=open(inputfilename)
+        inputfile=open(inputfilename, encoding='utf-8')
         data = list(inputfile)
         for line_nr in range(0,len(data)-1):
             if (data[line_nr].strip()=='//#name'):

--- a/definition_driver/prepare.py
+++ b/definition_driver/prepare.py
@@ -224,14 +224,14 @@ text = text + "}"
 # and replace "#template_holder" with text
 
 if nda:
-    nda_file=open(target_path+"IMPORTANT_README.txt","w")
+    nda_file=open(target_path+"IMPORTANT_README.txt","w",encoding="utf-8")
     nda_file.write(
 "This kernel module contains NDA information.\n"
 "Do not distribute it, do not copy it, do not make it available to anyone!\n"
 )
     nda_file.close()
-templatefile=open(template)
-targetfile=open(target,"w")
+templatefile=open(template,encoding="utf-8")
+targetfile=open(target,"w",encoding="utf-8")
 if nda:
     targetfile.write(
 "/*****************************************************************************/\n"


### PR DESCRIPTION
Intel_PERF_GLOBAL_STATUS.txt contains unicode characters which throws an error if default encoding `ascii` is used