### PR TITLE
Fix Linux 5.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ Its usage was initially presented at Ena-HPC 2013:
 
 Integrating performance analysis and energy efficiency optimizations in a unified environment, R Schöne, D Molka - Computer Science-Research and Development, 2014, [DOI:10.1007/s00450-013-0243-7](http://dx.doi.org/10.1007/s00450-013-0243-7)
 
+## About this Fork
+This fork **relicenses the entire code under GPL (v2 only)**.
+
+Background:
+Linux has locked down the abilities of proprietary kernel modules
+(which `x86_adapt` is flagged as to accomodate potential NDAs)
+essentially disabling the functionality of `x86_adapt`.
+
+The changes to the [upstream version](https://github.com/s9105947/x86_adapt) are minimal,
+i.e. all of the original credit is still required.
 
 ## Dependencies
 - python

--- a/debpack_template/DEBIAN/control
+++ b/debpack_template/DEBIAN/control
@@ -2,7 +2,7 @@ package: x86-adapt-driver
 version: ###VERSION###
 section: utils
 priority: extra
-depends: build-essential, dkms, python
+depends: build-essential, dkms, python3
 architecture: amd64
 maintainer: Michael Werner <michael.werner3@tu-dresden.de> 
 homepage: https://github.com/tud-zih-energy/x86_adapt

--- a/debpack_template/usr/src/x86_adapt_driver-template/dkms.conf
+++ b/debpack_template/usr/src/x86_adapt_driver-template/dkms.conf
@@ -4,6 +4,7 @@ PACKAGE_VERSION="###VERSION###"
 DEST_MODULE_LOCATION="/extra"
 BUILT_MODULE_NAME="x86_adapt_driver"
 BUILT_MODULE_LOCATION="src/"
+BUILD_DEPENDS="x86_adapt_defs"
 
 MAKE="'make' -C src/ all"
 CLEAN="'make' -C src/ clean"

--- a/debpack_template/usr/src/x86_adapt_driver-template/src/Makefile
+++ b/debpack_template/usr/src/x86_adapt_driver-template/src/Makefile
@@ -1,10 +1,11 @@
 
 obj-m += x86_adapt_driver.o
+
+KBUILD_EXTRA_SYMBOLS := ../definition_driver/x86_adapt_defs.o
  
 all:
 	$(eval DIRX = $(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))))
 	make -C $(DIRX)/../definition_driver all
-	cp $(DIRX)/../definition_driver/Module.symvers $(DIRX)
 	make -C /lib/modules/$(shell uname -r)/build M=$(DIRX) modules
  
 clean:

--- a/definition_driver/knobs/write_uncore_pmc_definitions.py
+++ b/definition_driver/knobs/write_uncore_pmc_definitions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 class HaswellPciBox:
 	prefix=None
@@ -42,7 +42,7 @@ class HaswellPciBox:
 
 	def print_one(self,register,name,descr,bitmask):
 		file_name = "{0}{1}_PMON_{2}.txt".format(self.prefix, self.name, name)
-		print("write file", file_name)
+		print(("write file", file_name))
 		f=open(file_name,"w")
 		text=""
 		text=text+"//#name\n"+self.name+"_PMON_"+name+"\n"
@@ -133,7 +133,7 @@ class Box:
 
 	def print_one(self,register,name,descr,bitmask):
 		file_name = "{0}{1}_PMON_{2}.txt".format(self.prefix, self.name, name)
-		print("write file", file_name)
+		print(("write file", file_name))
 		f=open(file_name,"w")
 		text=""
 		text=text+"//#name\n"+self.name+"_PMON_"+name+"\n"

--- a/definition_driver/x86_adapt_defs_template.c
+++ b/definition_driver/x86_adapt_defs_template.c
@@ -39,6 +39,6 @@ static void __exit x86_adapt_definition_exit(void)
 module_init(x86_adapt_definition_init);
 module_exit(x86_adapt_definition_exit);
 MODULE_AUTHOR("Robert Schoene <robert.schoene@tu-dresden.de>");
-MODULE_LICENSE("Proprietary");
+MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("x86 Adapt Processor Feature Device Definition Driver");
 MODULE_VERSION("0.1");

--- a/driver/x86_adapt_driver.c
+++ b/driver/x86_adapt_driver.c
@@ -698,12 +698,13 @@ __always_inline static u64 get_setting_from_register_reading(u64 register_readin
 
 __always_inline static int get_current_task_cpu(void)
 {
-#ifdef CONFIG_THREAD_INFO_IN_TASK
-    return current->cpu;
-#else
+#ifndef CONFIG_THREAD_INFO_IN_TASK
+    #error Kernel must be configured with CONFIG_THREAD_INFO_IN_TASK=y
+#endif
+
+    // note: provided iff CONFIG_THREAD_INFO_IN_TASK=y
     struct thread_info *ti =task_thread_info(current);
     return ti->cpu;
-#endif
 }
 
 /* reads the setting of msr / pci knob */

--- a/driver/x86_adapt_driver.c
+++ b/driver/x86_adapt_driver.c
@@ -1551,11 +1551,11 @@ static int __init x86_adapt_init(void)
 {
     int i,err;
 
-    get_online_cpus();
+    cpus_read_lock();
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
-    put_online_cpus();
+    cpus_read_unlock();
     cpu_notifier_register_begin();
 #endif
 #endif
@@ -1621,7 +1621,7 @@ static int __init x86_adapt_init(void)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
      /* >= 3.15, < 4.10 */
     __register_hotcpu_notifier(&x86_adapt_cpu_notifier);
-    put_online_cpus();
+    cpus_read_unlock();
 #else
     /* >= 4.10 */
 
@@ -1630,7 +1630,7 @@ static int __init x86_adapt_init(void)
     if (err < 0)
         goto fail;
     cpuhp_x86a_state = err;
-    put_online_cpus();
+    cpus_read_unlock();
 #endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
     /* >= 3.15, < 4.10 */
@@ -1639,7 +1639,7 @@ static int __init x86_adapt_init(void)
 #else
     /* < 3.15 */
     register_hotcpu_notifier(&x86_adapt_cpu_notifier);
-    put_online_cpus();
+    cpus_read_unlock();
 #endif
     
 
@@ -1700,10 +1700,10 @@ fail:
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
     cpu_notifier_register_done();
 #else
-    put_online_cpus();
+    cpus_read_unlock();
 #endif
 #else
-    put_online_cpus();
+    cpus_read_unlock();
 #endif
 
     return err;
@@ -1713,7 +1713,8 @@ static void __exit x86_adapt_exit(void)
 {
     int i;
 
-    get_online_cpus();
+    //get_online_cpus();
+    cpus_read_lock();
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
@@ -1774,7 +1775,7 @@ static void __exit x86_adapt_exit(void)
     class_destroy(x86_adapt_class);
     x86_adapt_class = NULL;
 
-    put_online_cpus();
+    cpus_read_unlock();
 
     printk(KERN_INFO "Shutting Down x86 Adapt Processor Feature Device Driver\n");
 }

--- a/generate-deb.sh
+++ b/generate-deb.sh
@@ -16,9 +16,10 @@ else
     REVISION=$1
 fi
 echo $REVISION
-sed -i "s/###VERSION###/$REVISION/g" debpack/DEBIAN/*
-sed -i "s/###VERSION###/$REVISION/g" debpack/usr/src/x86_adapt_defs-template/dkms.conf
-sed -i "s/###VERSION###/$REVISION/g" debpack/usr/src/x86_adapt_driver-template/*
+
+find debpack/DEBIAN -type f | xargs sed -i "s/###VERSION###/$REVISION/g"
+find debpack/usr/src/x86_adapt_defs-template -type f | xargs sed -i "s/###VERSION###/$REVISION/g"
+find debpack/usr/src/x86_adapt_driver-template -type f | xargs sed -i "s/###VERSION###/$REVISION/g"
 
 #create uncore knobs
 cd definition_driver/knobs


### PR DESCRIPTION
fixes two deprecated calls into the kernel to their updated versions.

Breaks compatibility to kernels with `CONFIG_THREAD_INFO_IN_TASK` disabled.
(This is checked and a CPP `#error` is created if this is the case.)